### PR TITLE
Prevent custom project names from being ignored

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,10 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
+## [1.2.0] - 2020-05-01
+### Fixed
+ - [#79](https://github.com/echebbi/eclipse-discord-integration/pull/79) Prevent [custom project names](https://discord-rich-presence-for-eclipse-ide.readthedocs.io/en/latest/customize/change-name-of-projects.html#) from being ignored
+
 ## [1.1.3] - 2020-05-01
 ### Added
  - [#67](https://github.com/echebbi/eclipse-discord-integration/issues/67) Deactivate Preferences fields when the plug-in is disabled

--- a/bundles/fr.kazejiyu.discord.rpc.integration.adapters/META-INF/MANIFEST.MF
+++ b/bundles/fr.kazejiyu.discord.rpc.integration.adapters/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: Discord Rich Presence for Eclipse IDE — Default Adapters
 Bundle-SymbolicName: fr.kazejiyu.discord.rpc.integration.adapters;singleton:=true
-Bundle-Version: 1.1.3
+Bundle-Version: 1.2.0
 Automatic-Module-Name: fr.kazejiyu.discord.rpc.integration.adapters
 Bundle-RequiredExecutionEnvironment: JavaSE-1.8
 Require-Bundle: fr.kazejiyu.discord.rpc.integration;bundle-version="0.8.2",

--- a/bundles/fr.kazejiyu.discord.rpc.integration.adapters/src/fr/kazejiyu/discord/rpc/integration/adapters/DefaultFileEditorInputRichPresence.java
+++ b/bundles/fr.kazejiyu.discord.rpc.integration.adapters/src/fr/kazejiyu/discord/rpc/integration/adapters/DefaultFileEditorInputRichPresence.java
@@ -92,7 +92,7 @@ public class DefaultFileEditorInputRichPresence implements EditorInputToRichPres
         template = template.replace("${file.baseName}", preferences.showsFileName() ? getBaseFileName(file) : "?");
         template = template.replace("${file.extension}", preferences.showsFileName() ? getFileExtension(file) : "?");
         template = template.replace("${language}", language.getName());
-        template = template.replace("${project}", preferences.showsProjectName() ? nameOf(project) : "?");
+        template = template.replace("${project}", preferences.showsProjectName() ? nameOf(project, preferences) : "?");
         
         return template;
     }
@@ -104,17 +104,17 @@ public class DefaultFileEditorInputRichPresence implements EditorInputToRichPres
         template = template.replace("${file.baseName}", preferences.showsFileName() ? getBaseFileName(file) : "?");
         template = template.replace("${file.extension}", preferences.showsFileName() ? getFileExtension(file) : "?");
         template = template.replace("${language}", language.getName());
-        template = template.replace("${project}", preferences.showsProjectName() ? nameOf(project) : "?");
+        template = template.replace("${project}", preferences.showsProjectName() ? nameOf(project, preferences) : "?");
         
         return template;
     }
 
     /** Returns either the name of the project, or "an unknown project" is project == null. */
-    private static String nameOf(IProject project) {
+    private static String nameOf(IProject project, UserPreferences preferences) {
         if (project == null) {
             return "an unknown project";
         }
-        return project.getName(); 
+        return preferences.getProjectName().orElseGet(project::getName);
     }
 
     private static Language languageOf(UserPreferences preferences, IFile file) {

--- a/bundles/fr.kazejiyu.discord.rpc.integration.ui.preferences/META-INF/MANIFEST.MF
+++ b/bundles/fr.kazejiyu.discord.rpc.integration.ui.preferences/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: Discord Rich Presence for Eclipse IDE — Preferences
 Bundle-SymbolicName: fr.kazejiyu.discord.rpc.integration.ui.preferences;singleton:=true
-Bundle-Version: 1.1.3
+Bundle-Version: 1.2.0
 Bundle-Activator: fr.kazejiyu.discord.rpc.integration.ui.preferences.Activator
 Require-Bundle: org.eclipse.ui;bundle-version="[3.107.0,4.0.0)",
  org.eclipse.core.runtime;bundle-version="[3.11.0,4.0.0)",

--- a/bundles/fr.kazejiyu.discord.rpc.integration/META-INF/MANIFEST.MF
+++ b/bundles/fr.kazejiyu.discord.rpc.integration/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: Discord Rich Presence for Eclipse IDE
 Bundle-SymbolicName: fr.kazejiyu.discord.rpc.integration;singleton:=true
-Bundle-Version: 1.1.3
+Bundle-Version: 1.2.0
 Bundle-Activator: fr.kazejiyu.discord.rpc.integration.Activator
 Require-Bundle: org.eclipse.ui;bundle-version="[3.107.0,4.0.0)",
  org.eclipse.core.runtime;bundle-version="[3.11.0,4.0.0)",

--- a/bundles/java-discord-rpc/pom.xml
+++ b/bundles/java-discord-rpc/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>fr.kazejiyu.discord.rpc.integration</groupId>
 		<artifactId>fr.kazejiyu.discord.rpc.integration.bundles</artifactId>
-		<version>1.1.3</version>
+		<version>1.2.0</version>
 	</parent>
 
 	<artifactId>java-discord-rpc</artifactId>

--- a/bundles/pom.xml
+++ b/bundles/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>fr.kazejiyu.discord.rpc.integration</groupId>
         <artifactId>fr.kazejiyu.discord.rpc.integration.root</artifactId>
-        <version>1.1.3</version>
+        <version>1.2.0</version>
     </parent>
 
 	<modules>

--- a/features/fr.kazejiyu.discord.rpc.integration.feature/feature.xml
+++ b/features/fr.kazejiyu.discord.rpc.integration.feature/feature.xml
@@ -2,7 +2,7 @@
 <feature
       id="fr.kazejiyu.discord.rpc.integration.feature"
       label="Discord Rich Presence"
-      version="1.1.3"
+      version="1.2.0"
       provider-name="Emmanuel CHEBBI">
 
    <description url="https://github.com/KazeJiyu/eclipse-discord-integration">
@@ -312,14 +312,14 @@ version(s), and exceptions or additional permissions here}.&quot;
          id="fr.kazejiyu.discord.rpc.integration.adapters"
          download-size="0"
          install-size="0"
-         version="1.1.3"
+         version="1.2.0"
          unpack="false"/>
 
    <plugin
          id="fr.kazejiyu.discord.rpc.integration"
          download-size="0"
          install-size="0"
-         version="1.1.3"
+         version="1.2.0"
          unpack="false"/>
 
 </feature>

--- a/features/fr.kazejiyu.discord.rpc.integration.ui.feature/feature.xml
+++ b/features/fr.kazejiyu.discord.rpc.integration.ui.feature/feature.xml
@@ -2,7 +2,7 @@
 <feature
       id="fr.kazejiyu.discord.rpc.integration.ui.feature"
       label="Discord Rich Presence UI"
-      version="1.1.3"
+      version="1.2.0"
       provider-name="Emmanuel CHEBBI">
 
    <description url="https://github.com/KazeJiyu/eclipse-discord-integration">
@@ -304,7 +304,7 @@ version(s), and exceptions or additional permissions here}.&quot;
          id="fr.kazejiyu.discord.rpc.integration.ui.preferences"
          download-size="0"
          install-size="0"
-         version="1.1.3"
+         version="1.2.0"
          unpack="false"/>
 
 </feature>

--- a/features/pom.xml
+++ b/features/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>fr.kazejiyu.discord.rpc.integration</groupId>
         <artifactId>fr.kazejiyu.discord.rpc.integration.root</artifactId>
-        <version>1.1.3</version>
+        <version>1.2.0</version>
     </parent>
     
 	<modules>

--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
 	<modelVersion>4.0.0</modelVersion>
 	<artifactId>fr.kazejiyu.discord.rpc.integration.root</artifactId>
     <groupId>fr.kazejiyu.discord.rpc.integration</groupId>
-    <version>1.1.3</version>
+    <version>1.2.0</version>
 	<packaging>pom</packaging>
 
 	<name>Discord Rich Presence for Eclipse IDE</name>
@@ -75,7 +75,7 @@
                         <artifact>
                             <groupId>fr.kazejiyu.discord.rpc.integration</groupId>
                             <artifactId>fr.kazejiyu.discord.rpc.integration.target</artifactId>
-                            <version>1.1.3</version>
+                            <version>1.2.0</version>
                         </artifact>
                     </target>
 					<environments>

--- a/releng/fr.kazejiyu.discord.rpc.integration.p2/category.xml
+++ b/releng/fr.kazejiyu.discord.rpc.integration.p2/category.xml
@@ -1,9 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <site>
-   <feature url="features/fr.kazejiyu.discord.rpc.integration.feature_1.1.3.jar" id="fr.kazejiyu.discord.rpc.integration.feature" version="1.1.3">
+   <feature url="features/fr.kazejiyu.discord.rpc.integration.feature_1.2.0.jar" id="fr.kazejiyu.discord.rpc.integration.feature" version="1.2.0">
       <category name="fr.kazejiyu.discord.rpc.integration"/>
    </feature>
-   <feature url="features/fr.kazejiyu.discord.rpc.integration.ui.feature_1.1.3.jar" id="fr.kazejiyu.discord.rpc.integration.ui.feature" version="1.1.3">
+   <feature url="features/fr.kazejiyu.discord.rpc.integration.ui.feature_1.2.0.jar" id="fr.kazejiyu.discord.rpc.integration.ui.feature" version="1.2.0">
       <category name="fr.kazejiyu.discord.rpc.integration"/>
    </feature>
    <category-def name="fr.kazejiyu.discord.rpc.integration" label="Discord Rich Presence Integration">

--- a/releng/fr.kazejiyu.discord.rpc.integration.p2/pom.xml
+++ b/releng/fr.kazejiyu.discord.rpc.integration.p2/pom.xml
@@ -7,7 +7,7 @@
 	<parent>
 		<groupId>fr.kazejiyu.discord.rpc.integration</groupId>
 		<artifactId>fr.kazejiyu.discord.rpc.integration.releng</artifactId>
-		<version>1.1.3</version>
+		<version>1.2.0</version>
 	</parent>
 
 	<artifactId>fr.kazejiyu.discord.rpc.integration.p2</artifactId>

--- a/releng/fr.kazejiyu.discord.rpc.integration.target/pom.xml
+++ b/releng/fr.kazejiyu.discord.rpc.integration.target/pom.xml
@@ -7,6 +7,6 @@
     <parent>
         <groupId>fr.kazejiyu.discord.rpc.integration</groupId>
         <artifactId>fr.kazejiyu.discord.rpc.integration.releng</artifactId>
-        <version>1.1.3</version>
+        <version>1.2.0</version>
     </parent>
 </project>

--- a/releng/pom.xml
+++ b/releng/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>fr.kazejiyu.discord.rpc.integration</groupId>
         <artifactId>fr.kazejiyu.discord.rpc.integration.root</artifactId>
-        <version>1.1.3</version>
+        <version>1.2.0</version>
     </parent>
     
 	<modules>

--- a/tests/fr.kazejiyu.discord.rpc.integration.adapters.tests/META-INF/MANIFEST.MF
+++ b/tests/fr.kazejiyu.discord.rpc.integration.adapters.tests/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: Discord Rich Presence for Eclipse IDE — Default Adapters (Tests)
 Bundle-SymbolicName: fr.kazejiyu.discord.rpc.integration.adapters.tests
-Bundle-Version: 1.1.3
+Bundle-Version: 1.2.0
 Bundle-Vendor: Emmanuel CHEBBI
 Fragment-Host: fr.kazejiyu.discord.rpc.integration.adapters;bundle-version="0.8.4"
 Automatic-Module-Name: fr.kazejiyu.discord.rpc.integration.adapters.tests

--- a/tests/fr.kazejiyu.discord.rpc.integration.adapters.tests/pom.xml
+++ b/tests/fr.kazejiyu.discord.rpc.integration.adapters.tests/pom.xml
@@ -7,6 +7,6 @@
 	<parent>
 		<groupId>fr.kazejiyu.discord.rpc.integration</groupId>
 		<artifactId>tests</artifactId>
-		<version>1.1.3</version>
+		<version>1.2.0</version>
 	</parent>
 </project>

--- a/tests/fr.kazejiyu.discord.rpc.integration.tests.report/pom.xml
+++ b/tests/fr.kazejiyu.discord.rpc.integration.tests.report/pom.xml
@@ -8,7 +8,7 @@
 	<parent>
 		<groupId>fr.kazejiyu.discord.rpc.integration</groupId>
 		<artifactId>tests</artifactId>
-		<version>1.1.3</version>
+		<version>1.2.0</version>
 	</parent>
 
 	<profiles>
@@ -41,25 +41,25 @@
 		<dependency>
 			<groupId>fr.kazejiyu.discord.rpc.integration</groupId>
 			<artifactId>fr.kazejiyu.discord.rpc.integration</artifactId>
-			<version>1.1.3</version>
+			<version>1.2.0</version>
 			<scope>compile</scope>
 		</dependency>
 		<dependency>
 			<groupId>fr.kazejiyu.discord.rpc.integration</groupId>
 			<artifactId>fr.kazejiyu.discord.rpc.integration.tests</artifactId>
-			<version>1.1.3</version>
+			<version>1.2.0</version>
 			<scope>test</scope>
 		</dependency>
 		<dependency>
 			<groupId>fr.kazejiyu.discord.rpc.integration</groupId>
 			<artifactId>fr.kazejiyu.discord.rpc.integration.adapters</artifactId>
-			<version>1.1.3</version>
+			<version>1.2.0</version>
 			<scope>compile</scope>
 		</dependency>
 		<dependency>
 			<groupId>fr.kazejiyu.discord.rpc.integration</groupId>
 			<artifactId>fr.kazejiyu.discord.rpc.integration.adapters.tests</artifactId>
-			<version>1.1.3</version>
+			<version>1.2.0</version>
 			<scope>test</scope>
 		</dependency>
 	</dependencies>

--- a/tests/fr.kazejiyu.discord.rpc.integration.tests/META-INF/MANIFEST.MF
+++ b/tests/fr.kazejiyu.discord.rpc.integration.tests/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: Discord Rich Presence for Eclipse IDE (Tests)
 Bundle-SymbolicName: fr.kazejiyu.discord.rpc.integration.tests
-Bundle-Version: 1.1.3
+Bundle-Version: 1.2.0
 Bundle-Vendor: Emmanuel CHEBBI
 Fragment-Host: fr.kazejiyu.discord.rpc.integration;bundle-version="0.8.4"
 Automatic-Module-Name: fr.kazejiyu.discord.rpc.integration.tests

--- a/tests/fr.kazejiyu.discord.rpc.integration.tests/pom.xml
+++ b/tests/fr.kazejiyu.discord.rpc.integration.tests/pom.xml
@@ -7,6 +7,6 @@
 	<parent>
 		<groupId>fr.kazejiyu.discord.rpc.integration</groupId>
 		<artifactId>tests</artifactId>
-		<version>1.1.3</version>
+		<version>1.2.0</version>
 	</parent>
 </project>

--- a/tests/pom.xml
+++ b/tests/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>fr.kazejiyu.discord.rpc.integration</groupId>
         <artifactId>fr.kazejiyu.discord.rpc.integration.root</artifactId>
-        <version>1.1.3</version>
+        <version>1.2.0</version>
     </parent>
 
 	<modules>


### PR DESCRIPTION
I have been a bit too quick merging #78; this PR fixes a regression preventing [custom project names](https://discord-rich-presence-for-eclipse-ide.readthedocs.io/en/latest/customize/change-name-of-projects.html#) from being ignored.

I bump the version to `1.2.0` because #78 introduced a new feature and should have incremented the 'minor' version.